### PR TITLE
refactor boards : the boardlist conetexts are moved to context processors

### DIFF
--- a/seeseehome/seeseehome/context_processors.py
+++ b/seeseehome/seeseehome/context_processors.py
@@ -1,0 +1,12 @@
+from boards.models import Board
+
+
+def board_list(request):
+    """
+    render Google Analytics tracking ID ( UA-********-* ) to template
+    """
+    boardlist = Board.objects.all()
+
+    return {
+        'boardlist': boardlist
+    }

--- a/seeseehome/seeseehome/settings.py
+++ b/seeseehome/seeseehome/settings.py
@@ -34,12 +34,9 @@ SECRET_KEY = 't6g+nq2ba%na%(fxbm%ino##c@4+pn&+68j5spm+!nu2e)*6^b'
 DEBUG = True
 TEMPLATE_DEBUG = True
 
-#ALLOWED_HOSTS = []
 ALLOWED_HOSTS = ['127.0.0.1', 'localhost', '220.149.86.220', 'see.ssu.ac.kr', '0.0.0.0']
-#ALLOWED_HOSTS = ['*']
 
 # Application definition
-
 INSTALLED_APPS = (
     'django.contrib.admin',
     'django.contrib.auth',
@@ -47,14 +44,29 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    #   Custom apps
+
+    # Apps
     'users',
     'boards',
     'linkboard',
 
-    #   Django Packages
+    # Django Packages
     'ckeditor',
     'multiselectfield',
+)
+
+TEMPLATE_CONTEXT_PROCESSORS = (
+    # Django Default
+    "django.contrib.auth.context_processors.auth",
+    "django.core.context_processors.debug",
+    "django.core.context_processors.i18n",
+    "django.core.context_processors.media",
+    "django.core.context_processors.static",
+    "django.core.context_processors.tz",
+    "django.contrib.messages.context_processors.messages",
+
+    # Custom context processors
+    'seeseehome.context_processors.board_list',
 )
 
 MIDDLEWARE_CLASSES = (
@@ -97,7 +109,7 @@ DATABASES = {
 
 LANGUAGE_CODE = 'ko-kr'
 
-#TIME_ZONE = 'UTC'
+# TIME_ZONE = 'UTC'
 TIME_ZONE = 'Asia/Seoul'
 
 USE_I18N = True

--- a/seeseehome/users/views.py
+++ b/seeseehome/users/views.py
@@ -62,9 +62,7 @@ def signin(request):
         if 'next' in request.GET:
             next = request.GET['next']
 
-        boardlist = Board.objects.all()
-        return render(request, "users/signin.html", {'next': next,
-                                                     'boardlist': boardlist})
+        return render(request, "users/signin.html", {'next': next})
 
         return render(request, "users/signin.html", {'next': next})
 
@@ -163,15 +161,12 @@ def signup(request):
         messages.info(request, msg.users_signup_success_info)
         return HttpResponseRedirect(reverse("users:signin"))
 
-    boardlist = Board.objects.all()
-    return render(request, "users/signup.html", {'boardlist': boardlist})
+    return render(request, "users/signup.html")
 
 
 @login_required
 def personalinfo(request):
-    boardlist = Board.objects.all()
-    return render(request, "users/personalinfo.html",
-                  {'boardlist': boardlist})
+    return render(request, "users/personalinfo.html")
 
 
 @login_required
@@ -251,9 +246,7 @@ def editpersonalinfo(request):
         messages.success(request, msg.users_editpersonalinfo_success)
         return HttpResponseRedirect(reverse("users:personalinfo"))
 
-    boardlist = Board.objects.all()
-    return render(request, "users/editpersonalinfo.html",
-                  {'boardlist': boardlist})
+    return render(request, "users/editpersonalinfo.html")
 
 
 @login_required
@@ -292,5 +285,4 @@ def editpassword(request):
         messages.info(request, msg.users_change_pwd_success_info)
         return HttpResponseRedirect(reverse("users:signin"))
 
-    boardlist = Board.objects.all()
-    return render(request, "users/editpwd.html", {'boardlist': boardlist})
+    return render(request, "users/editpwd.html")


### PR DESCRIPTION
기존에 boardlist는 공통된 컨텍스트이지만 각 뷰마다 더해주었습니다. 불필요한 반복을 줄이고자 컨텍스트를  `seeseehome/context_processors.py`로 옮겼습니다.